### PR TITLE
Backport #153 to release/v1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,22 +71,22 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
-      <version>1.64.0</version>
+      <version>1.65.1</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
-      <version>1.65.0</version>
+      <version>1.65.1</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>1.65.0</version>
+      <version>1.65.1</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>1.65.0</version>
+      <version>1.65.1</version>
     </dependency>
     <dependency>
       <groupId>build.buf</groupId>


### PR DESCRIPTION
SSIA

## NOTE

E2E fails because java is not updated. If there is a problem after the release, this PR will be reverted.

- https://github.com/vdaas/vald-client-clj/pull/147
- https://github.com/vdaas/vald-client-clj/pull/148
- https://github.com/vdaas/vald-client-clj/pull/149
- https://github.com/vdaas/vald-client-clj/pull/150