### PR TITLE
Backport to release/v1.2 for update deps (#171) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,32 +66,32 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.4</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
-      <version>1.65.1</version>
+      <version>1.64.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
-      <version>1.65.1</version>
+      <version>1.64.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>1.65.1</version>
+      <version>1.64.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>1.65.1</version>
+      <version>1.64.0</version>
     </dependency>
     <dependency>
       <groupId>build.buf</groupId>
       <artifactId>protovalidate</artifactId>
-      <version>0.1.8</version>
+      <version>0.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.vdaas.vald</groupId>


### PR DESCRIPTION
Backport: https://github.com/vdaas/vald-client-clj/pull/171